### PR TITLE
feat: send/sync for node and guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 documentation = "https://docs.rs/clhlock"
 repository = "https://github.com/pedromfedricci/clhlock"
 authors = ["Pedro de Matos Fedricci <pedromfedricci@gmail.com>"]
-categories = ["no-std", "concurrency"]
-keywords = ["no_std", "mutex", "spin-lock", "clh-lock"]
+categories = ["algorithms", "concurrency", "no-std"]
+keywords = ["mutex", "no_std", "spinlock", "synchronization"]
 
 [features]
 # NOTE: Features `yield` and `thread_local` require std.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Or add a entry under the `[dependencies]` section in your `Cargo.toml`:
 # Cargo.toml
 
 [dependencies]
-# Available features: `yield` and thread_local`.
-clhlock = { version = "0.1", features = ["yield, thread_local"] }
+# Available features: `yield` and `thread_local`.
+clhlock = { version = "0.1", features = ["yield", "thread_local"] }
 ```
 
 ## Documentation
@@ -66,7 +66,7 @@ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
 ## Waiting queue node allocations
 
 Queue nodes are allocated in the heap, and their ownership is transparently
-moved from the lock holding thread to it successor. Allocationg the nodes in
+moved from the lock holding thread to its successor. Allocating the nodes in
 the stack is not allowed since the CLH lock protocol does not guarantee that
 a predecessor thread will be live by the time a successor access its
 associated locking node. Locking operations require exclusive access to local

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! ## Waiting queue node allocations
 //!
 //! Queue nodes are allocated in the heap, and their ownership is transparently
-//! moved from the lock holding thread to it successor. Allocationg the nodes in
+//! moved from the lock holding thread to its successor. Allocating the nodes in
 //! the stack is not allowed since the CLH lock protocol does not guarantee that
 //! a predecessor thread will be live by the time a successor access its
 //! associated locking node. Locking operations require exclusive access to local

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -27,6 +27,10 @@ pub struct MutexNode {
     inner: inner::MutexNode<AtomicBool>,
 }
 
+// Same unsafe impls as `crate::inner::raw::MutexNode`.
+unsafe impl Send for MutexNode {}
+unsafe impl Sync for MutexNode {}
+
 impl MutexNode {
     /// Creates new `MutexNode` instance.
     ///
@@ -294,6 +298,10 @@ impl<T, R> From<T> for Mutex<T, R> {
 }
 
 impl<T: ?Sized + Debug, R: Relax> Debug for Mutex<T, R> {
+    /// Formats the mutex's value using the given formatter.
+    ///
+    /// This will lock the mutex to do so. If the lock is already held by the
+    /// thread, calling this function will cause a deadlock.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
@@ -352,7 +360,7 @@ pub struct MutexGuard<'a, T: ?Sized, R> {
 }
 
 // Same unsafe impls as `crate::inner::raw::MutexGuard`.
-// unsafe impl<T: ?Sized + Send, R> Send for MutexGuard<'_, T, R> {}
+unsafe impl<T: ?Sized + Send, R> Send for MutexGuard<'_, T, R> {}
 unsafe impl<T: ?Sized + Sync, R> Sync for MutexGuard<'_, T, R> {}
 
 #[doc(hidden)]

--- a/src/raw/thread_local.rs
+++ b/src/raw/thread_local.rs
@@ -109,7 +109,7 @@ impl LocalMutexNode {
     }
 
     /// Creates a new Loom based `LocalMutexNode` key from the provided thread
-    /// local node key (non-const).
+    /// local node key.
     #[cfg(all(loom, test))]
     #[must_use]
     pub(crate) const fn new(key: &'static LocalKey<RefCell<MutexNode>>) -> Self {
@@ -222,6 +222,11 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// check if the current thread local node is already mutably borrowed. If
     /// the current thread local node is already borrowed, calling this
     /// function is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the key currently has its destructor running, and it **may**
+    /// panic if the destructor has previously been run for this thread.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Add Send and Sync for [raw::MutexNode](https://docs.rs/clhlock/latest/clhlock/raw/struct.MutexNode.html) and [raw::MutexGuard](https://docs.rs/clhlock/latest/clhlock/raw/struct.MutexGuard.html).