### PR TITLE
fix!: unmark Relax trait as unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ An implementation of Craig and, indenpendently, Magnussen, Landin, and
 Hagersten queue lock for mutual exclusion, referred to as CLH lock.
 """
 name = "clhlock"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 # NOTE: Rust 1.70 is required for `AtomicPtr::as_ptr`.
 rust-version = "1.70.0"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or add a entry under the `[dependencies]` section in your `Cargo.toml`:
 
 [dependencies]
 # Available features: `yield` and `thread_local`.
-clhlock = { version = "0.1", features = ["yield", "thread_local"] }
+clhlock = { version = "0.2", features = ["yield", "thread_local"] }
 ```
 
 ## Documentation


### PR DESCRIPTION
**Breaking:**
- [`relax::Relax`](https://docs.rs/clhlock/latest/clhlock/relax/trait.Relax.html) is no longer marked as a unsafe trait.